### PR TITLE
fix: typo archives => archived

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -41,8 +41,8 @@
 <h2>Archives</h2>
 <p>These documents were developed by this community group but are not considered current or necessarily complete.</p>
 <ul>
-<li><a href="archives/synchronized-narration.html">Synchronized Narration</a></li>
-<li><a href="archives/incorporating-synchronized-narration.html">Incorporating Synchronized Narration into a Publication Manifest</a></li>
+<li><a href="archived/synchronized-narration.html">Synchronized Narration</a></li>
+<li><a href="archived/incorporating-synchronized-narration.html">Incorporating Synchronized Narration into a Publication Manifest</a></li>
 </ul>
 </section>
 </body>

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -30,5 +30,5 @@ The following are the currently available draft documents:
 
 These documents were developed by this community group but are not considered current or necessarily complete.
 
-* [Synchronized Narration](archives/synchronized-narration.html)
-* [Incorporating Synchronized Narration into a Publication Manifest](archives/incorporating-synchronized-narration.html)
+* [Synchronized Narration](archived/synchronized-narration.html)
+* [Incorporating Synchronized Narration into a Publication Manifest](archived/incorporating-synchronized-narration.html)


### PR DESCRIPTION
Links for "Synchronized Narration" and "Incorporating Synchronized Narration into a Publication Manifest"﻿
had a typo in their paths. Folder is named archived not archives
